### PR TITLE
Release pipeline

### DIFF
--- a/.github/workflows/core-ci.yml
+++ b/.github/workflows/core-ci.yml
@@ -26,9 +26,6 @@ jobs:
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
             cargo-tool: cargo
-          - os: macos-13
-            target: x86_64-apple-darwin
-            cargo-tool: cargo
           - os: macos-latest
             target: aarch64-apple-darwin
             cargo-tool: cargo

--- a/.github/workflows/core-ci.yml
+++ b/.github/workflows/core-ci.yml
@@ -44,7 +44,6 @@ jobs:
   format:
     name: format
     runs-on: ubuntu-latest
-    needs: test
     if: success()
     steps:
       - name: Checkout repository
@@ -61,7 +60,6 @@ jobs:
   lint:
     name: lint
     runs-on: ubuntu-latest
-    needs: test
     if: success()
     steps:
       - name: Checkout repository

--- a/.github/workflows/core-ci.yml
+++ b/.github/workflows/core-ci.yml
@@ -1,18 +1,14 @@
 name: Interpreter CI
-
 on:
   pull_request:
   push:
     branches:
       - main
-
 permissions:
   contents: read
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
-
 jobs:
   test:
     name: test
@@ -24,75 +20,43 @@ jobs:
         toolchain: [stable]
         target:
           - x86_64-unknown-linux-gnu
-          # - x86_64-apple-darwin
-          # - aarch64-apple-darwin
+          - x86_64-apple-darwin
+          - aarch64-apple-darwin
         include:
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
             cargo-tool: cargo
-          # - os: macos-13 # intel
-          #   target: x86_64-apple-darwin
-          #   cargo-tool: cargo
-          # - os: macos-latest # aarch64
-          #   target: aarch64-apple-darwin
-          #   cargo-tool: cargo
+          - os: macos-13
+            target: x86_64-apple-darwin
+            cargo-tool: cargo
+          - os: macos-latest
+            target: aarch64-apple-darwin
+            cargo-tool: cargo
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ matrix.toolchain }}
           target: ${{ matrix.target }}
-
       - name: Run tests
         working-directory: ./core
         run: make test
-  
-  # test-windows:
-  #   runs-on: windows-latest
-  #   timeout-minutes: 10
-  #   strategy:
-  #     fail-fast: false
-  #   steps:
-  #     - name: Checkout repository
-  #       uses: actions/checkout@v4
-
-  #     - name: Install Rust toolchain
-  #       uses: dtolnay/rust-toolchain@stable
-  #       with:
-  #         toolchain: stable
-  #         target: x86_64-pc-windows-gnu
-      
-  #     - name: Setup MSYS2
-  #       uses: msys2/setup-msys2@v2
-  #       with:
-  #         update: true
-  #         install: >-
-  #           diffutils
-  #           m4
-  #           make
-  #           mingw-w64-x86_64-gcc
-      
-  #     - name: Run tests
-  #       shell: msys2 {0}
-  #       working-directory: ./core
-  #       run: make test
 
   format:
     name: format
     runs-on: ubuntu-latest
+    needs: test
+    if: success()
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: stable
           components: rustfmt
-      
       - name: Check formatting
         working-directory: ./core
         run: make fmt-check
@@ -100,16 +64,16 @@ jobs:
   lint:
     name: lint
     runs-on: ubuntu-latest
+    needs: test
+    if: success()
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: stable
           components: clippy
-
       - name: Run linter
         working-directory: ./core
         run: make lint

--- a/.github/workflows/core-ci.yml
+++ b/.github/workflows/core-ci.yml
@@ -21,7 +21,6 @@ jobs:
         toolchain: [stable]
         target:
           - x86_64-unknown-linux-gnu
-          - x86_64-apple-darwin
           - aarch64-apple-darwin
         include:
           - os: ubuntu-latest

--- a/.github/workflows/core-ci.yml
+++ b/.github/workflows/core-ci.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-    workflow_call:
+  workflow_call:
 permissions:
   contents: read
 concurrency:

--- a/.github/workflows/core-ci.yml
+++ b/.github/workflows/core-ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+    workflow_call:
 permissions:
   contents: read
 concurrency:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,10 @@ jobs:
         with:
           targets: ${{ matrix.target }}
       - run: cargo build --all-features --release --target ${{ matrix.target }}
+      - name: Smoke test
+        run: |
+          echo 'println("Smoke test!")' > /tmp/test.komodo
+          target/${{ matrix.target }}/release/komodo /tmp/test.komodo
       - name: Rename binary
         run: mv target/${{ matrix.target }}/release/komodo target/${{ matrix.target }}/release/komodo-${{ matrix.target }}
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,8 +24,6 @@ jobs:
         include:
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
-          - os: macos-13
-            target: x86_64-apple-darwin
           - os: macos-latest
             target: aarch64-apple-darwin
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
           targets: ${{ matrix.target }}
       - run: cargo build --all-features --release --target ${{ matrix.target }}
       - name: Rename binary
-        run: mv core/target/${{ matrix.target }}/release/komodo core/target/${{ matrix.target }}/release/komodo-${{ matrix.target }}
+        run: mv target/${{ matrix.target }}/release/komodo target/${{ matrix.target }}/release/komodo-${{ matrix.target }}
       - uses: actions/upload-artifact@v4
         with:
           name: komodo-${{ matrix.target }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           name: komodo-${{ matrix.target }}
-          path: target/${{ matrix.target }}/release/komodo
+          path: core/target/${{ matrix.target }}/release/komodo
 
   release:
     needs: [version, build]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,8 @@ jobs:
         with:
           targets: ${{ matrix.target }}
       - run: cargo build --all-features --release --target ${{ matrix.target }}
+      - name: Rename binary
+        run: mv core/target/${{ matrix.target }}/release/komodo core/target/${{ matrix.target }}/release/komodo-${{ matrix.target }}
       - uses: actions/upload-artifact@v4
         with:
           name: komodo-${{ matrix.target }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,54 @@
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  version:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.get_version.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Get version from Cargo.toml
+        id: get_version
+        run: |
+          VERSION=$(grep '^version' core/Cargo.toml | head -1 | sed 's/version = "\(.*\)"/\1/')
+          echo "version=v$VERSION" >> $GITHUB_OUTPUT
+
+  build:
+    needs: version
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+          - os: macos-13
+            target: x86_64-apple-darwin
+          - os: macos-latest
+            target: aarch64-apple-darwin
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+      - run: cargo build --all-features --release --target ${{ matrix.target }}
+      - uses: actions/upload-artifact@v4
+        with:
+          name: komodo-${{ matrix.target }}
+          path: target/${{ matrix.target }}/release/komodo
+
+  release:
+    needs: [version, build]
+    if: success()
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+      - uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ needs.version.outputs.version }}
+          files: artifacts/**/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,8 +36,10 @@ jobs:
         include:
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
+            name: linux-x64
           - os: macos-latest
             target: aarch64-apple-darwin
+            name: macos-arm64
     runs-on: ${{ matrix.os }}
     defaults:
       run:
@@ -56,8 +58,12 @@ jobs:
         run: mv target/${{ matrix.target }}/release/komodo target/${{ matrix.target }}/release/komodo-${{ matrix.target }}
       - uses: actions/upload-artifact@v4
         with:
-          name: komodo-${{ matrix.target }}
+          name: komodo-${{ matrix.name }}
           path: core/target/${{ matrix.target }}/release/komodo-${{ matrix.target }}
+      - uses: actions/upload-artifact@v4
+        with:
+          name: utils.komodo
+          path: std/utils.komodo
 
   release:
     needs: [version, build]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,9 @@ jobs:
           - os: macos-latest
             target: aarch64-apple-darwin
     runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        working-directory: ./core
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,3 +1,5 @@
+name: Release
+
 on:
   workflow_dispatch:
 
@@ -5,7 +7,12 @@ permissions:
   contents: write
 
 jobs:
+  ci:
+    uses: ./.github/workflows/core-ci.yml
+
   version:
+    needs: ci
+    if: success()
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.get_version.outputs.version }}
@@ -18,7 +25,8 @@ jobs:
           echo "version=v$VERSION" >> $GITHUB_OUTPUT
 
   build:
-    needs: version
+    needs: [ci, version]
+    if: success()
     strategy:
       matrix:
         include:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,7 +55,7 @@ jobs:
           echo 'println("Smoke test!")' > /tmp/test.komodo
           target/${{ matrix.target }}/release/komodo /tmp/test.komodo
       - name: Rename binary
-        run: mv target/${{ matrix.target }}/release/komodo target/${{ matrix.target }}/release/komodo-${{ matrix.target }}
+        run: mv target/${{ matrix.target }}/release/komodo target/${{ matrix.target }}/release/komodo-${{ matrix.name }}
       - uses: actions/upload-artifact@v4
         with:
           name: komodo-${{ matrix.name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           name: komodo-${{ matrix.target }}
-          path: core/target/${{ matrix.target }}/release/komodo
+          path: core/target/${{ matrix.target }}/release/komodo-${{ matrix.target }}
 
   release:
     needs: [version, build]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,7 +59,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           name: komodo-${{ matrix.name }}
-          path: core/target/${{ matrix.target }}/release/komodo-${{ matrix.target }}
+          path: core/target/${{ matrix.target }}/release/komodo-${{ matrix.name }}
       - uses: actions/upload-artifact@v4
         with:
           name: utils.komodo

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,14 +14,18 @@ jobs:
     needs: ci
     if: success()
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./core
     outputs:
       version: ${{ steps.get_version.outputs.version }}
     steps:
       - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
       - name: Get version from Cargo.toml
         id: get_version
         run: |
-          VERSION=$(grep '^version' core/Cargo.toml | head -1 | sed 's/version = "\(.*\)"/\1/')
+          VERSION=$(cargo pkgid | cut -d "@" -f2)
           echo "version=v$VERSION" >> $GITHUB_OUTPUT
 
   build:


### PR DESCRIPTION
Added a GitHub Actions Release workflow with macOS support. Feel free to suggest any changes :)

### Changes

- **macOS build support:** added `aarch64-apple-darwin`.
- **Reusable CI workflow:** `core-ci.yml` now exposes a `workflow_call` trigger so it can be called from other workflows.
- **Release pipeline:** new `release.yml` triggered manually via `workflow_dispatch`. It reads the version from `Cargo.toml` automatically, runs the full CI suite, builds binaries for Linux and macOS, and publishes them as a GitHub release.

Note sure if komodo has CLI, so I added a smoke test by running a simple program from a file.

Hope you like it.